### PR TITLE
Inspect Command

### DIFF
--- a/habulara.cabal
+++ b/habulara.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7bfd8597895058fbf0f8230d08d2e92c0a697a1a00f481f86a774aef8dd9a11d
+-- hash: 02ad258bbba0720eed6351841b6431e31ff9bd672cdc0cbd2feea79b5c2d1101
 
 name:           habulara
 version:        0.0.0.4
@@ -48,6 +48,7 @@ library
       Data.Habulara.Dsl
       Data.Habulara.Dsl.Operators
       Data.Habulara.Dsl.Specification
+      Data.Habulara.Inspect.Internal
   other-modules:
       Paths_habulara
   hs-source-dirs:
@@ -66,6 +67,7 @@ library
     , scientific
     , text
     , time
+    , typed-process
     , unordered-containers
     , vector
     , yaml
@@ -92,6 +94,7 @@ executable habulara
     , scientific
     , text
     , time
+    , typed-process
     , unordered-containers
     , vector
     , yaml
@@ -121,6 +124,7 @@ test-suite habulara-doctest
     , scientific
     , text
     , time
+    , typed-process
     , unordered-containers
     , vector
     , yaml
@@ -151,6 +155,7 @@ test-suite habulara-test
     , scientific
     , text
     , time
+    , typed-process
     , unordered-containers
     , vector
     , yaml

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ dependencies:
 - scientific
 - text
 - time
+- typed-process
 - unordered-containers
 - vector
 - yaml

--- a/src/Data/Habulara/Inspect/Internal.hs
+++ b/src/Data/Habulara/Inspect/Internal.hs
@@ -1,23 +1,21 @@
 {-# LANGUAGE LambdaCase #-}
 module Data.Habulara.Inspect.Internal where
 
-import           Control.Monad                   (mzero)
-import           Control.Monad.IO.Class          (MonadIO, liftIO)
-import qualified Data.Aeson                      as Aeson
-import qualified Data.ByteString.Char8           as BC
-import qualified Data.ByteString.Lazy            as BL
-import qualified Data.ByteString.Lazy.Char8      as BLC
-import           Data.Csv                        ((.:))
-import qualified Data.Csv                        as Csv
-import           Data.Habulara.Dsl.Specification (FieldSpec(..), MappingSpec(..))
-import qualified Data.HashMap.Strict             as HM
-import qualified Data.List.NonEmpty              as NE
-import           Data.Maybe                      (fromMaybe)
-import qualified Data.Text                       as T
-import qualified Data.Vector                     as V
-import qualified Data.Yaml                       as YAML
-import           System.Exit                     (ExitCode(..))
-import qualified System.Process.Typed            as P
+import           Control.Monad              (mzero)
+import           Control.Monad.IO.Class     (MonadIO, liftIO)
+import qualified Data.Aeson                 as Aeson
+import qualified Data.ByteString.Char8      as BC
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import           Data.Csv                   ((.:))
+import qualified Data.Csv                   as Csv
+import qualified Data.HashMap.Strict        as HM
+import           Data.Maybe                 (fromMaybe)
+import qualified Data.Text                  as T
+import qualified Data.Vector                as V
+import qualified Data.Yaml                  as YAML
+import           System.Exit                (ExitCode(..))
+import qualified System.Process.Typed       as P
 
 
 inspect :: MonadIO m => FilePath -> m ExitCode
@@ -49,8 +47,8 @@ prepareSpec ss = Aeson.Object $ HM.fromList
       ]) : mkFields xs
 
     mkOps x = case statType x of
-      StatFieldTypeFloat   -> [select, Aeson.Object $ HM.fromList [("name", "asNumber")]]
-      StatFieldTypeInteger -> [select, Aeson.Object $ HM.fromList [("name", "asNumber")]]
+      StatFieldTypeFloat   -> [select, Aeson.Object $ HM.fromList [("name", "asText")]]
+      StatFieldTypeInteger -> [select, Aeson.Object $ HM.fromList [("name", "asText")]]
       StatFieldTypeUnicode -> [select, Aeson.Object $ HM.fromList [("name", "asText")]]
       StatFieldTypeNULL    -> [select, Aeson.Object $ HM.fromList [("name", "asEmpty")]]
       where

--- a/src/Data/Habulara/Inspect/Internal.hs
+++ b/src/Data/Habulara/Inspect/Internal.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE LambdaCase #-}
+module Data.Habulara.Inspect.Internal where
+
+import           Control.Monad                   (mzero)
+import           Control.Monad.IO.Class          (MonadIO, liftIO)
+import qualified Data.Aeson                      as Aeson
+import qualified Data.ByteString.Char8           as BC
+import qualified Data.ByteString.Lazy            as BL
+import qualified Data.ByteString.Lazy.Char8      as BLC
+import           Data.Csv                        ((.:))
+import qualified Data.Csv                        as Csv
+import           Data.Habulara.Dsl.Specification (FieldSpec(..), MappingSpec(..))
+import qualified Data.HashMap.Strict             as HM
+import qualified Data.List.NonEmpty              as NE
+import           Data.Maybe                      (fromMaybe)
+import qualified Data.Text                       as T
+import qualified Data.Vector                     as V
+import qualified Data.Yaml                       as YAML
+import           System.Exit                     (ExitCode(..))
+import qualified System.Process.Typed            as P
+
+
+inspect :: MonadIO m => FilePath -> m ExitCode
+inspect fp = runXsv fp >>= \case
+  Left err -> liftIO (putStrLn err) >> pure (ExitFailure 1)
+  Right st -> do
+    let estat = fmap (V.toList . snd) (Csv.decodeByName st) :: Either String [Stat]
+    case estat of
+      Left err -> liftIO (putStrLn err) >> pure (ExitFailure 2)
+      Right ss -> liftIO (BC.putStr $ YAML.encode $ prepareSpec ss) >> pure ExitSuccess
+
+
+prepareSpec :: [Stat] -> Aeson.Value
+prepareSpec ss = Aeson.Object $ HM.fromList
+  [ ("name", Aeson.String "<NAME>")
+  , ("description", Aeson.String "<DESCRIPTION>")
+  , ("delimiter", Aeson.String ",")
+  , ("encoding", Aeson.String "utf-8")
+  , ("fields", Aeson.Array $ V.fromList $ mkFields ss)
+  ]
+  where
+    mkFields :: [Stat] -> [Aeson.Value]
+    mkFields [] = []
+    mkFields (x : xs) = Aeson.Object (HM.fromList
+      [ ("label", Aeson.String $ statField x)
+      , ("title", Aeson.String $ statField x)
+      , ("description", Aeson.String $ T.pack $ mkDescription x)
+      , ("operation", Aeson.Array $ V.fromList $ mkOps x)
+      ]) : mkFields xs
+
+    mkOps x = case statType x of
+      StatFieldTypeFloat   -> [select, Aeson.Object $ HM.fromList [("name", "asNumber")]]
+      StatFieldTypeInteger -> [select, Aeson.Object $ HM.fromList [("name", "asNumber")]]
+      StatFieldTypeUnicode -> [select, Aeson.Object $ HM.fromList [("name", "asText")]]
+      StatFieldTypeNULL    -> [select, Aeson.Object $ HM.fromList [("name", "asEmpty")]]
+      where
+        select = Aeson.Object $ HM.fromList [("name", Aeson.String "select"), ("args", Aeson.Array $ V.fromList [Aeson.String $ statField x])]
+
+    mkDescription x =
+         "- Name:         " <> T.unpack (statField x) <> "\n"
+      <> "- Type:         " <> show (statType x) <> "\n"
+      <> "- Min:          " <> fromMaybe "#N/A" (statMin x) <> "\n"
+      <> "- Max:          " <> fromMaybe "#N/A" (statMax x) <> "\n"
+      <> "- Min Length:   " <> fromMaybe "#N/A" (statMinLength x) <> "\n"
+      <> "- Max Length:   " <> fromMaybe "#N/A" (statMaxLength x) <> "\n"
+      <> "- Stddev:       " <> fromMaybe "#N/A" (statStddev x) <> "\n"
+      <> "- Mean:         " <> fromMaybe "#N/A" (statMean x) <> "\n"
+      <> "- Median:       " <> fromMaybe "#N/A" (statMedian x) <> "\n"
+      <> "- Cardinality:  " <> fromMaybe "#N/A" (statCardinality x) <> "\n"
+
+
+runXsv :: MonadIO m => FilePath -> m (Either String BL.ByteString)
+runXsv fp = do
+  (ec, out, err) <- P.readProcess $ P.proc "xsv" ["stats", "--median", "--cardinality", fp]
+  case ec of
+    ExitSuccess   -> pure $ Right out
+    ExitFailure c -> pure . Left $ "ERROR! `xsv` process exited with code " <> show c <> ". Message was: " <> BLC.unpack err
+
+
+data Stat = Stat
+  { statField       :: !T.Text
+  , statType        :: !StatFieldType
+  , statMin         :: !(Maybe String)
+  , statMax         :: !(Maybe String)
+  , statMinLength   :: !(Maybe String)
+  , statMaxLength   :: !(Maybe String)
+  , statMean        :: !(Maybe String)
+  , statStddev      :: !(Maybe String)
+  , statMedian      :: !(Maybe String)
+  , statCardinality :: !(Maybe String)
+  } deriving Show
+
+
+instance Csv.FromNamedRecord Stat where
+  parseNamedRecord m = Stat
+    <$> m .: "field"
+    <*> m .: "type"
+    <*> m .: "min"
+    <*> m .: "max"
+    <*> m .: "min_length"
+    <*> m .: "max_length"
+    <*> m .: "mean"
+    <*> m .: "stddev"
+    <*> m .: "median"
+    <*> m .: "cardinality"
+
+
+data StatFieldType =
+    StatFieldTypeFloat
+  | StatFieldTypeInteger
+  | StatFieldTypeUnicode
+  | StatFieldTypeNULL
+  deriving Show
+
+
+instance Csv.FromField StatFieldType where
+  parseField s
+    | s == "Float"   = pure StatFieldTypeFloat
+    | s == "Integer" = pure StatFieldTypeInteger
+    | s == "Unicode" = pure StatFieldTypeUnicode
+    | s == "NULL"    = pure StatFieldTypeNULL
+    | otherwise = mzero

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-16.28
+resolver: lts-16.31
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 533053
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/28.yaml
-    sha256: a9c01d860ac8dfb3a1b6f7ec4a36dd9504a95392b89c99b0877da63fa36a8e97
-  original: lts-16.28
+    size: 534126
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
+  original: lts-16.31


### PR DESCRIPTION
Added `inspect` command that uses xsv under the hood and produces a Habulara specification file as per `xsv stats` command output.
